### PR TITLE
Add option to ignore files listed in .gitignore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "ignore": "^7.0.5",
         "minimatch": "^9.0.3"
       },
       "devDependencies": {
@@ -261,6 +262,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -474,6 +485,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2070,6 +2091,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2540,6 +2571,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2732,10 +2773,9 @@
       "optional": true
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
           ],
           "description": "Glob patterns for files to exclude"
         },
+        "fileChangeFollower.respectGitignore": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ignore files that are listed in .gitignore"
+        },
         "fileChangeFollower.debounceMs": {
           "type": "number",
           "default": 150,
@@ -118,6 +123,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "ignore": "^7.0.5",
     "minimatch": "^9.0.3"
   }
 }

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 import { minimatch } from 'minimatch';
+import ignore, { Ignore } from 'ignore';
 import { ConfigurationManager } from './configuration';
 import { debounce, Debouncer } from './debounce';
 
@@ -17,6 +20,7 @@ export class ChangeFollower implements vscode.Disposable {
     private processChangesDebouncer: Debouncer | undefined;
     private highlightDecorationType: vscode.TextEditorDecorationType | undefined;
     private activeHighlights: Map<string, NodeJS.Timeout> = new Map();
+    private gitignoreCache: Map<string, Ignore> = new Map();
 
     constructor(configManager: ConfigurationManager) {
         this.configManager = configManager;
@@ -61,6 +65,7 @@ export class ChangeFollower implements vscode.Disposable {
     onConfigurationChanged(): void {
         this.setupDebouncer();
         this.setupHighlightDecoration();
+        this.gitignoreCache.clear();
     }
 
     private setupDebouncer(): void {
@@ -182,6 +187,11 @@ export class ChangeFollower implements vscode.Disposable {
             }
         }
 
+        // Check .gitignore if enabled
+        if (this.configManager.respectGitignore && this.isIgnoredByGitignore(uri)) {
+            return false;
+        }
+
         // Check include patterns
         for (const pattern of this.configManager.includePatterns) {
             if (minimatch(relativePath, pattern, { dot: true })) {
@@ -190,6 +200,44 @@ export class ChangeFollower implements vscode.Disposable {
         }
 
         return false;
+    }
+
+    private isIgnoredByGitignore(uri: vscode.Uri): boolean {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+        if (!workspaceFolder) {
+            return false;
+        }
+
+        const workspaceRoot = workspaceFolder.uri.fsPath;
+        const ig = this.getGitignore(workspaceRoot);
+        if (!ig) {
+            return false;
+        }
+
+        const relativePath = path.relative(workspaceRoot, uri.fsPath);
+        // Normalize path separators for cross-platform compatibility
+        const normalizedPath = relativePath.split(path.sep).join('/');
+        return ig.ignores(normalizedPath);
+    }
+
+    private getGitignore(workspaceRoot: string): Ignore | undefined {
+        if (this.gitignoreCache.has(workspaceRoot)) {
+            return this.gitignoreCache.get(workspaceRoot);
+        }
+
+        const gitignorePath = path.join(workspaceRoot, '.gitignore');
+        try {
+            if (fs.existsSync(gitignorePath)) {
+                const content = fs.readFileSync(gitignorePath, 'utf8');
+                const ig = ignore().add(content);
+                this.gitignoreCache.set(workspaceRoot, ig);
+                return ig;
+            }
+        } catch {
+            // Failed to read .gitignore, continue without it
+        }
+
+        return undefined;
     }
 
     private queueChange(uri: vscode.Uri, ranges: vscode.Range[]): void {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,4 +36,8 @@ export class ConfigurationManager {
     get highlightDuration(): number {
         return this.config.get<number>('highlightDuration', 2000);
     }
+
+    get respectGitignore(): boolean {
+        return this.config.get<boolean>('respectGitignore', true);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new espectGitignore setting (default: 	rue) that prevents the extension from following changes to files that are listed in the workspace's .gitignore file.

## Changes

- Added ignore package for parsing .gitignore files
- Added new configuration option \ileChangeFollower.respectGitignore\ (defaults to \	rue\)
- Updated \ChangeFollower\ to check files against \.gitignore\ patterns before following
- Gitignore patterns are cached per workspace for performance

## Testing

1. Enable follow mode
2. Create a file that matches a pattern in \.gitignore\ (e.g., a file in \
ode_modules/\)
3. Verify the extension does not follow changes to that file
4. Set \ileChangeFollower.respectGitignore\ to \alse\
5. Verify the extension now follows changes to previously ignored files

Fixes #2