### PR TITLE
Fix extension failing to load due to missing ignore package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,4 @@ node_modules/**
 !node_modules/minimatch/**
 !node_modules/brace-expansion/**
 !node_modules/balanced-match/**
+!node_modules/ignore/**

--- a/src/test/suite/gitignore.test.ts
+++ b/src/test/suite/gitignore.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert';
+import ignore from 'ignore';
+
+suite('Gitignore Integration Test Suite', () => {
+    test('ignore package should be loadable', () => {
+        // This test verifies that the 'ignore' package is properly bundled
+        // and can be loaded at runtime. This prevents regression of issue #7
+        // where the package was missing from the VSIX.
+        assert.ok(typeof ignore === 'function', 'ignore should be a function');
+    });
+
+    test('ignore package should create functional instance', () => {
+        const ig = ignore();
+        assert.ok(ig, 'ignore() should return an instance');
+        assert.ok(typeof ig.add === 'function', 'instance should have add method');
+        assert.ok(typeof ig.ignores === 'function', 'instance should have ignores method');
+    });
+
+    test('ignore package should correctly filter paths', () => {
+        const ig = ignore().add(['node_modules/', '*.log', 'dist/']);
+
+        // Should ignore these paths
+        assert.strictEqual(ig.ignores('node_modules/package/index.js'), true);
+        assert.strictEqual(ig.ignores('error.log'), true);
+        assert.strictEqual(ig.ignores('dist/bundle.js'), true);
+
+        // Should not ignore these paths
+        assert.strictEqual(ig.ignores('src/index.ts'), false);
+        assert.strictEqual(ig.ignores('package.json'), false);
+    });
+
+    test('ignore package should handle negation patterns', () => {
+        const ig = ignore().add(['*.log', '!important.log']);
+
+        assert.strictEqual(ig.ignores('debug.log'), true);
+        assert.strictEqual(ig.ignores('important.log'), false);
+    });
+});


### PR DESCRIPTION
## Summary

The 'ignore' npm package was not included in the packaged VSIX because it was missing from the .vscodeignore whitelist. This caused the extension to fail to load with a module resolution error when users installed v0.2.0.

## Changes

- Add \!node_modules/ignore/**\ to .vscodeignore whitelist to include the package in the VSIX
- Add regression tests to verify the ignore package loads and functions correctly

## Root Cause

When the 'respect gitignore' feature was added in v0.2.0, the \ignore\ npm package was added as a dependency but was not added to the whitelist in \.vscodeignore\. Since this file excludes all of \
ode_modules/**\ by default and only includes specific whitelisted packages, the \ignore\ package was missing from the packaged extension.

## Testing

- Verified the package compiles successfully
- Verified the VSIX now includes \
ode_modules/ignore/\
- Added 4 new tests that verify the ignore package is loadable and functional

Fixes #7