### PR TITLE
Add quick install scripts to dev release description

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   dev-release:
+    # Only run on direct pushes to main, not from PR merges or other refs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: dev
 


### PR DESCRIPTION
## Summary

Adds copy-pasteable shell script snippets to the Development Build release description for easy one-command installation.

## Changes

- Added **Quick Install** section with collapsible VS Code and VS Code Insiders options
- **Bash scripts** (macOS/Linux) using \curl\ to download and install the extension
- **Cross-platform PowerShell scripts** (Windows/macOS/Linux) using \Invoke-WebRequest\
- Renamed existing instructions to **Manual Installation**

## How it works

The scripts:
1. Query the GitHub API to get the latest .vsix asset URL
2. Download to a temp file
3. Install using \code --install-extension\ or \code-insiders --install-extension\
4. Clean up the temp file