### PR TITLE
feat: Auto-disable follow mode on manual edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
           "default": true,
           "description": "Ignore files that are listed in .gitignore"
         },
+        "fileChangeFollower.disableOnManualEdit": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically disable follow mode when a manual edit is made in the editor"
+        },
         "fileChangeFollower.debounceMs": {
           "type": "number",
           "default": 150,

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -21,6 +21,8 @@ export class ChangeFollower implements vscode.Disposable {
     private highlightDecorationType: vscode.TextEditorDecorationType | undefined;
     private activeHighlights: Map<string, NodeJS.Timeout> = new Map();
     private gitignoreCache: Map<string, Ignore> = new Map();
+    private readonly _onDidAutoDisable = new vscode.EventEmitter<void>();
+    readonly onDidAutoDisable = this._onDidAutoDisable.event;
 
     constructor(configManager: ConfigurationManager) {
         this.configManager = configManager;
@@ -50,7 +52,7 @@ export class ChangeFollower implements vscode.Disposable {
         vscode.window.showInformationMessage('File Change Follower: Follow mode enabled');
     }
 
-    disable(): void {
+    disable(silent = false): void {
         if (!this._isEnabled) {
             return;
         }
@@ -59,7 +61,9 @@ export class ChangeFollower implements vscode.Disposable {
         this.clearListeners();
         this.pendingChanges.clear();
         this.clearAllHighlights();
-        vscode.window.showInformationMessage('File Change Follower: Follow mode disabled');
+        if (!silent) {
+            vscode.window.showInformationMessage('File Change Follower: Follow mode disabled');
+        }
     }
 
     onConfigurationChanged(): void {
@@ -130,6 +134,19 @@ export class ChangeFollower implements vscode.Disposable {
         // Skip if no content changes
         if (event.contentChanges.length === 0) {
             return;
+        }
+
+        // Detect manual edits: if the changed document is the active editor's document,
+        // the user is actively editing (the extension opens docs with preserveFocus: true,
+        // so the active editor only matches when the user explicitly switches to it)
+        if (this.configManager.disableOnManualEdit) {
+            const activeEditor = vscode.window.activeTextEditor;
+            if (activeEditor && activeEditor.document.uri.toString() === uri.toString()) {
+                this.disable(true);
+                this._onDidAutoDisable.fire();
+                vscode.window.showInformationMessage('File Change Follower: Follow mode auto-disabled due to manual edit');
+                return;
+            }
         }
 
         // Check if file matches patterns
@@ -360,6 +377,7 @@ export class ChangeFollower implements vscode.Disposable {
     dispose(): void {
         this.disable();
         this.highlightDecorationType?.dispose();
+        this._onDidAutoDisable.dispose();
         this.clearListeners();
     }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,6 +29,10 @@ export class ConfigurationManager {
         ]);
     }
 
+    get disableOnManualEdit(): boolean {
+        return this.config.get<boolean>('disableOnManualEdit', true);
+    }
+
     get debounceMs(): number {
         return this.config.get<number>('debounceMs', 150);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,6 +193,11 @@ export function activate(context: vscode.ExtensionContext): void {
         }
     );
 
+    // Listen for auto-disable events from ChangeFollower
+    const autoDisableListener = changeFollower.onDidAutoDisable(() => {
+        updateStatusBar();
+    });
+
     // Listen to configuration changes
     const configChangeListener = vscode.workspace.onDidChangeConfiguration((e) => {
         if (e.affectsConfiguration('fileChangeFollower')) {
@@ -219,6 +224,7 @@ export function activate(context: vscode.ExtensionContext): void {
         catchUpToLiveCommand,
         showTimelineCommand,
         configChangeListener,
+        autoDisableListener,
         playerStateListener,
         timelineView,
         statusBarManager,

--- a/src/test/suite/changeFollower.test.ts
+++ b/src/test/suite/changeFollower.test.ts
@@ -1,0 +1,169 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { ChangeFollower } from '../../changeFollower';
+import { ConfigurationManager } from '../../configuration';
+
+suite('ChangeFollower Auto-Disable Test Suite', () => {
+    let configManager: ConfigurationManager;
+    let changeFollower: ChangeFollower;
+    let tempDir: string;
+
+    setup(() => {
+        configManager = new ConfigurationManager();
+        changeFollower = new ChangeFollower(configManager);
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcf-test-'));
+    });
+
+    teardown(() => {
+        changeFollower.dispose();
+        // Clean up temp files
+        try {
+            fs.rmSync(tempDir, { recursive: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    });
+
+    test('Should auto-disable when active editor document is changed', async () => {
+        // Enable follow mode
+        changeFollower.enable();
+        assert.strictEqual(changeFollower.isEnabled, true);
+
+        // Create and open a temp file so it becomes the active editor
+        const tempFile = path.join(tempDir, 'test-manual-edit.txt');
+        fs.writeFileSync(tempFile, 'initial content');
+        const uri = vscode.Uri.file(tempFile);
+        const doc = await vscode.workspace.openTextDocument(uri);
+        // Open without preserveFocus so it becomes the active editor
+        const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+
+        // Verify the active editor is our document
+        assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), uri.toString());
+
+        // Track auto-disable event
+        let autoDisableFired = false;
+        const disposable = changeFollower.onDidAutoDisable(() => {
+            autoDisableFired = true;
+        });
+
+        // Simulate a manual edit by typing into the active editor
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 0), 'manual edit ');
+        });
+
+        // Give a moment for the event to propagate
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        // Follow mode should be auto-disabled
+        assert.strictEqual(changeFollower.isEnabled, false, 'Follow mode should be auto-disabled after manual edit');
+        assert.strictEqual(autoDisableFired, true, 'onDidAutoDisable event should have fired');
+
+        disposable.dispose();
+    });
+
+    test('Should NOT auto-disable when a non-active document is changed externally', async () => {
+        // Enable follow mode
+        changeFollower.enable();
+        assert.strictEqual(changeFollower.isEnabled, true);
+
+        // Create a temp file and open it as the active editor
+        const activeFile = path.join(tempDir, 'active-file.txt');
+        fs.writeFileSync(activeFile, 'active content');
+        const activeUri = vscode.Uri.file(activeFile);
+        const activeDoc = await vscode.workspace.openTextDocument(activeUri);
+        await vscode.window.showTextDocument(activeDoc, { preserveFocus: false });
+
+        // Create a different temp file and modify it externally (not the active editor)
+        const externalFile = path.join(tempDir, 'external-file.txt');
+        fs.writeFileSync(externalFile, 'initial content');
+
+        // Track auto-disable event
+        let autoDisableFired = false;
+        const disposable = changeFollower.onDidAutoDisable(() => {
+            autoDisableFired = true;
+        });
+
+        // Modify the external file on disk
+        fs.writeFileSync(externalFile, 'modified externally');
+
+        // Give a moment for events to propagate
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        // Follow mode should still be enabled
+        assert.strictEqual(changeFollower.isEnabled, true, 'Follow mode should remain enabled for external changes');
+        assert.strictEqual(autoDisableFired, false, 'onDidAutoDisable should NOT have fired');
+
+        disposable.dispose();
+    });
+
+    test('Should NOT auto-disable when disableOnManualEdit setting is disabled', async () => {
+        // Enable follow mode
+        changeFollower.enable();
+        assert.strictEqual(changeFollower.isEnabled, true);
+
+        // Update the setting to disable auto-disable
+        await vscode.workspace.getConfiguration('fileChangeFollower').update('disableOnManualEdit', false, vscode.ConfigurationTarget.Global);
+        configManager.reload();
+
+        // Create and open a temp file so it becomes the active editor
+        const tempFile = path.join(tempDir, 'test-no-auto-disable.txt');
+        fs.writeFileSync(tempFile, 'initial content');
+        const uri = vscode.Uri.file(tempFile);
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+
+        // Track auto-disable event
+        let autoDisableFired = false;
+        const disposable = changeFollower.onDidAutoDisable(() => {
+            autoDisableFired = true;
+        });
+
+        // Simulate a manual edit
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 0), 'manual edit ');
+        });
+
+        // Give a moment for events to propagate
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        // Follow mode should still be enabled
+        assert.strictEqual(changeFollower.isEnabled, true, 'Follow mode should remain enabled when disableOnManualEdit is false');
+        assert.strictEqual(autoDisableFired, false, 'onDidAutoDisable should NOT have fired');
+
+        // Clean up the setting
+        await vscode.workspace.getConfiguration('fileChangeFollower').update('disableOnManualEdit', undefined, vscode.ConfigurationTarget.Global);
+        disposable.dispose();
+    });
+
+    test('onDidAutoDisable event emitter fires callback', async () => {
+        changeFollower.enable();
+
+        let callCount = 0;
+        const disposable = changeFollower.onDidAutoDisable(() => {
+            callCount++;
+        });
+
+        // Create and open a temp file as active editor
+        const tempFile = path.join(tempDir, 'test-event-emitter.txt');
+        fs.writeFileSync(tempFile, 'initial content');
+        const uri = vscode.Uri.file(tempFile);
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+
+        // Make a manual edit
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 0), 'edit ');
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        // Should have fired exactly once (disable happens on first edit, subsequent edits
+        // won't trigger because follow mode is already disabled)
+        assert.strictEqual(callCount, 1, 'onDidAutoDisable should fire exactly once');
+
+        disposable.dispose();
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new setting \ileChangeFollower.disableOnManualEdit\ (default: \	rue\) that automatically disables follow mode when the user makes a manual edit in the editor. This prevents the confusing behavior where the extension highlights and scrolls to the user's own changes.

## How it works

Manual edits are detected by checking if the changed document belongs to \scode.window.activeTextEditor\. Since the extension always opens documents with \preserveFocus: true\, the active editor only matches when the user has explicitly focused on a file to edit it. External changes (from CLI tools, file watchers, etc.) don't trigger the active editor match.

## Changes

- **\package.json\**: Added \ileChangeFollower.disableOnManualEdit\ configuration option (boolean, default: true)
- **\src/configuration.ts\**: Added \disableOnManualEdit\ getter to \ConfigurationManager\
- **\src/changeFollower.ts\**: 
  - Added \onDidAutoDisable\ event emitter
  - Added manual edit detection in \handleTextDocumentChange\
  - Added \silent\ parameter to \disable()\ to avoid double notifications
- **\src/extension.ts\**: Wired up \onDidAutoDisable\ listener to update status bar
- **\src/test/suite/changeFollower.test.ts\**: Added unit tests for auto-disable behavior

Closes #11