### PR TITLE
fix: increase debounce test timing margins for CI reliability

### DIFF
--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -42,17 +42,17 @@ suite('Debounce Test Suite', () => {
         let callCount = 0;
         const debouncer = debounce(() => {
             callCount++;
-        }, 30);
+        }, 50);
 
         debouncer.call();
 
         setTimeout(() => {
             debouncer.call();
-        }, 80);
+        }, 150);
 
         setTimeout(() => {
             assert.strictEqual(callCount, 2);
             done();
-        }, 200);
+        }, 400);
     });
 });


### PR DESCRIPTION
## Summary

Fixes the flaky \Debounce Test Suite > Should allow calls after debounce period\ test that failed on \macos-latest\ CI runners.

## Problem

The test used tight timing margins (30ms debounce, second call at 80ms, assertion at 200ms) that were insufficient on slower macOS CI runners, causing the second debounced call to not resolve before the assertion.

## Fix

Increased timing margins:
- Debounce delay: 30ms → 50ms
- Second call gap: 80ms → 150ms  
- Assertion timeout: 200ms → 400ms

This gives ~200ms of margin for the second debounce to fire before the assertion, which should be reliable on all CI platforms.