### PR TITLE
fix: prevent auto-disable on external file changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "file-change-follower",
   "displayName": "File Change Follower",
   "description": "Follow file changes in real-time - automatically opens and scrolls to edits as they happen. Perfect for watching CLI-based coding agents work.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "DamianEdwards",
   "license": "MIT",
   "icon": "assets/icon-256x256.png",

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -21,6 +21,8 @@ export class ChangeFollower implements vscode.Disposable {
     private highlightDecorationType: vscode.TextEditorDecorationType | undefined;
     private activeHighlights: Map<string, NodeJS.Timeout> = new Map();
     private gitignoreCache: Map<string, Ignore> = new Map();
+    private recentExternalChanges: Map<string, NodeJS.Timeout> = new Map();
+    private static readonly EXTERNAL_CHANGE_WINDOW_MS = 2000;
     private readonly _onDidAutoDisable = new vscode.EventEmitter<void>();
     readonly onDidAutoDisable = this._onDidAutoDisable.event;
 
@@ -61,6 +63,7 @@ export class ChangeFollower implements vscode.Disposable {
         this.clearListeners();
         this.pendingChanges.clear();
         this.clearAllHighlights();
+        this.clearAllExternalChangeTracking();
         if (!silent) {
             vscode.window.showInformationMessage('File Change Follower: Follow mode disabled');
         }
@@ -136,16 +139,23 @@ export class ChangeFollower implements vscode.Disposable {
             return;
         }
 
-        // Detect manual edits: if the changed document is the active editor's document,
-        // the user is actively editing (the extension opens docs with preserveFocus: true,
-        // so the active editor only matches when the user explicitly switches to it)
+        // Detect manual edits: if the changed document is the active editor's document
+        // and the change was NOT from an external file modification, the user is actively
+        // editing. External changes are tracked via the file system watcher which fires
+        // before VS Code reloads the document.
         if (this.configManager.disableOnManualEdit) {
             const activeEditor = vscode.window.activeTextEditor;
             if (activeEditor && activeEditor.document.uri.toString() === uri.toString()) {
-                this.disable(true);
-                this._onDidAutoDisable.fire();
-                vscode.window.showInformationMessage('File Change Follower: Follow mode auto-disabled due to manual edit');
-                return;
+                const key = uri.toString();
+                if (this.recentExternalChanges.has(key)) {
+                    // Change originated from disk, not the user typing
+                    this.clearExternalChangeTracking(key);
+                } else {
+                    this.disable(true);
+                    this._onDidAutoDisable.fire();
+                    vscode.window.showInformationMessage('File Change Follower: Follow mode auto-disabled due to manual edit');
+                    return;
+                }
             }
         }
 
@@ -176,6 +186,11 @@ export class ChangeFollower implements vscode.Disposable {
     }
 
     private handleFileChanged(uri: vscode.Uri): void {
+        // Track that this file was changed externally (on disk), so that when VS Code
+        // reloads the document and fires onDidChangeTextDocument, we don't mistake
+        // it for a manual user edit
+        this.trackExternalChange(uri);
+
         // File changed externally - only handle if not already open
         const openDocument = vscode.workspace.textDocuments.find(
             doc => doc.uri.toString() === uri.toString()
@@ -255,6 +270,30 @@ export class ChangeFollower implements vscode.Disposable {
         }
 
         return undefined;
+    }
+
+    private trackExternalChange(uri: vscode.Uri): void {
+        const key = uri.toString();
+        this.clearExternalChangeTracking(key);
+        const timer = setTimeout(() => {
+            this.recentExternalChanges.delete(key);
+        }, ChangeFollower.EXTERNAL_CHANGE_WINDOW_MS);
+        this.recentExternalChanges.set(key, timer);
+    }
+
+    private clearExternalChangeTracking(key: string): void {
+        const existing = this.recentExternalChanges.get(key);
+        if (existing) {
+            clearTimeout(existing);
+            this.recentExternalChanges.delete(key);
+        }
+    }
+
+    private clearAllExternalChangeTracking(): void {
+        for (const timer of this.recentExternalChanges.values()) {
+            clearTimeout(timer);
+        }
+        this.recentExternalChanges.clear();
     }
 
     private queueChange(uri: vscode.Uri, ranges: vscode.Range[]): void {
@@ -378,6 +417,7 @@ export class ChangeFollower implements vscode.Disposable {
         this.disable();
         this.highlightDecorationType?.dispose();
         this._onDidAutoDisable.dispose();
+        this.clearAllExternalChangeTracking();
         this.clearListeners();
     }
 }

--- a/src/test/suite/changeFollower.test.ts
+++ b/src/test/suite/changeFollower.test.ts
@@ -138,6 +138,41 @@ suite('ChangeFollower Auto-Disable Test Suite', () => {
         disposable.dispose();
     });
 
+    test('Should NOT auto-disable when external process modifies active editor document', async () => {
+        // This is the core bug scenario: user has a file focused, CLI agent modifies it
+        // on disk, VS Code reloads it, and follow mode should NOT be disabled.
+        changeFollower.enable();
+        assert.strictEqual(changeFollower.isEnabled, true);
+
+        // Create and open a temp file as the active editor (user is reading it)
+        const tempFile = path.join(tempDir, 'test-external-active.txt');
+        fs.writeFileSync(tempFile, 'initial content');
+        const uri = vscode.Uri.file(tempFile);
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc, { preserveFocus: false });
+
+        // Verify it's the active editor
+        assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), uri.toString());
+
+        // Track auto-disable event
+        let autoDisableFired = false;
+        const disposable = changeFollower.onDidAutoDisable(() => {
+            autoDisableFired = true;
+        });
+
+        // Simulate an external process (CLI agent) modifying the file on disk
+        fs.writeFileSync(tempFile, 'modified by CLI agent');
+
+        // Give time for file system watcher and document reload events to propagate
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Follow mode should still be enabled because the change was external
+        assert.strictEqual(changeFollower.isEnabled, true, 'Follow mode should remain enabled for external changes to the active editor');
+        assert.strictEqual(autoDisableFired, false, 'onDidAutoDisable should NOT have fired for external changes');
+
+        disposable.dispose();
+    });
+
     test('onDidAutoDisable event emitter fires callback', async () => {
         changeFollower.enable();
 


### PR DESCRIPTION
## Problem

The auto-disable feature (added in #12) incorrectly disables follow mode when a CLI-based coding agent modifies a file that happens to be the active editor. The user doesn't need to be typing — just having the file focused is enough to trigger the false positive.

**Root cause:** \onDidChangeTextDocument\ fires for both user edits *and* VS Code reloading files modified externally on disk. The detection logic only checked whether the changed document matched the active editor, which isn't sufficient to distinguish the two cases.

## Fix

Uses the existing file system watcher (\onDidChange\) to track recently externally-changed files. The key insight is that for external changes, the event ordering is:

1. \FileSystemWatcher.onDidChange\ fires
2. VS Code reloads the document buffer
3. \workspace.onDidChangeTextDocument\ fires

For user-initiated edits (typing), only step 3 occurs — no file system event precedes it.

By recording externally-changed file URIs when the file system watcher fires, we can check that set in \handleTextDocumentChange\ and skip the auto-disable when the change originated from disk.

## Changes

- **\src/changeFollower.ts\**: Added \ecentExternalChanges\ map to track files modified on disk, with a 2-second cleanup window. Updated \handleFileChanged\ to record external changes before the open-document early return. Updated manual edit detection to check the map and skip auto-disable for external changes. Added cleanup in \disable()\ and \dispose()\.
- **\src/test/suite/changeFollower.test.ts\**: Added test covering the core bug scenario (external process modifies the active editor's document → follow mode should remain enabled).

Fixes #11