### PR TITLE
fix: handle async errors and race conditions in debounce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ vsc-change-agent-watch/
 
 ## Build & Development Commands
 
+Use Node.js 22 or newer for development and testing; `@vscode/test-electron` requires it.
+
 ```bash
 # Install dependencies
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-change-follower",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-change-follower",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "ignore": "^7.0.5",
@@ -19,7 +19,7 @@
         "@types/vscode": "^1.85.0",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
-        "@vscode/test-electron": "^2.3.8",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^2.22.0",
         "eslint": "^8.56.0",
         "mocha": "^10.2.0",
@@ -698,9 +698,9 @@
       "license": "ISC"
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -711,7 +711,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
-    "@vscode/test-electron": "^2.3.8",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^2.22.0",
     "eslint": "^8.56.0",
     "mocha": "^10.2.0",

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -340,29 +340,36 @@ export class ChangeFollower implements vscode.Disposable {
 
     private async showChange(change: PendingChange): Promise<void> {
         try {
-            // Open the document
+            if (!this._isEnabled) {
+                return;
+            }
+
             const document = await vscode.workspace.openTextDocument(change.uri);
             
-            // Show the document without stealing focus from the terminal
+            if (!this._isEnabled) {
+                return;
+            }
+
             const editor = await vscode.window.showTextDocument(document, {
                 preview: false,
                 preserveFocus: true
             });
 
-            // Find the best range to reveal (prefer last change)
+            if (!this._isEnabled || editor !== vscode.window.visibleTextEditors.find(e => e === editor)) {
+                return;
+            }
+
             const rangeToReveal = change.ranges.length > 0 
                 ? change.ranges[change.ranges.length - 1]
                 : new vscode.Range(0, 0, 0, 0);
 
-            // Scroll to the change
+            await new Promise(resolve => setTimeout(resolve, 0));
             editor.revealRange(rangeToReveal, vscode.TextEditorRevealType.InCenter);
 
-            // Highlight the changed lines
             if (this.configManager.highlightDuration > 0 && this.highlightDecorationType) {
                 this.applyHighlight(editor, change.ranges);
             }
         } catch (error) {
-            // File might have been deleted or is binary
             console.log(`File Change Follower: Could not open ${change.uri.fsPath}:`, error);
         }
     }

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -355,7 +355,7 @@ export class ChangeFollower implements vscode.Disposable {
                 preserveFocus: true
             });
 
-            if (!this._isEnabled || editor !== vscode.window.visibleTextEditors.find(e => e === editor)) {
+            if (!this._isEnabled || !vscode.window.visibleTextEditors.includes(editor)) {
                 return;
             }
 
@@ -363,7 +363,6 @@ export class ChangeFollower implements vscode.Disposable {
                 ? change.ranges[change.ranges.length - 1]
                 : new vscode.Range(0, 0, 0, 0);
 
-            await new Promise(resolve => setTimeout(resolve, 0));
             editor.revealRange(rangeToReveal, vscode.TextEditorRevealType.InCenter);
 
             if (this.configManager.highlightDuration > 0 && this.highlightDecorationType) {

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -14,9 +14,13 @@ export function debounce(
             if (timeoutId) {
                 clearTimeout(timeoutId);
             }
-            timeoutId = setTimeout(() => {
+            timeoutId = setTimeout(async () => {
                 timeoutId = undefined;
-                fn();
+                try {
+                    await fn();
+                } catch (error) {
+                    console.error('Debounced function error:', error);
+                }
             }, delayMs);
         },
         cancel: () => {

--- a/src/test/suite/changeFollower.test.ts
+++ b/src/test/suite/changeFollower.test.ts
@@ -202,3 +202,87 @@ suite('ChangeFollower Auto-Disable Test Suite', () => {
         disposable.dispose();
     });
 });
+
+suite('ChangeFollower Lifecycle Test Suite', () => {
+    let changeFollower: ChangeFollower;
+    let tempDir: string;
+    let uri: vscode.Uri;
+    const disposables: vscode.Disposable[] = [];
+
+    setup(() => {
+        const configManager = new class extends ConfigurationManager {
+            override get highlightDuration(): number {
+                return 2000;
+            }
+        }();
+        changeFollower = new ChangeFollower(configManager);
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcf-lifecycle-test-'));
+        uri = vscode.Uri.file(path.join(tempDir, 'change.txt'));
+        fs.writeFileSync(uri.fsPath, 'changed content');
+    });
+
+    teardown(async () => {
+        for (const disposable of disposables) {
+            disposable.dispose();
+        }
+        disposables.length = 0;
+        changeFollower.dispose();
+
+        const tabs = vscode.window.tabGroups.all.flatMap(group => group.tabs).filter(
+            tab => tab.input instanceof vscode.TabInputText && tab.input.uri.toString() === uri.toString()
+        );
+        await vscode.window.tabGroups.close(tabs, true);
+        await fs.promises.rm(tempDir, { recursive: true, maxRetries: 5, retryDelay: 100 });
+    });
+
+    function showChange(): Promise<void> {
+        return changeFollower['showChange']({
+            uri,
+            ranges: [new vscode.Range(0, 0, 0, 0)],
+            timestamp: Date.now()
+        });
+    }
+
+    test('Should not open a document when already disabled', async () => {
+        await showChange();
+
+        assert.strictEqual(vscode.workspace.textDocuments.some(doc => doc.uri.toString() === uri.toString()), false);
+    });
+
+    test('Should not show a document when disabled while opening it', async () => {
+        changeFollower.enable();
+        disposables.push(vscode.workspace.onDidOpenTextDocument(document => {
+            if (document.uri.toString() === uri.toString()) {
+                changeFollower.disable(true);
+            }
+        }));
+
+        await showChange();
+
+        assert.strictEqual(changeFollower.isEnabled, false);
+        assert.strictEqual(vscode.window.visibleTextEditors.some(editor => editor.document.uri.toString() === uri.toString()), false);
+    });
+
+    test('Should not highlight an editor when disabled while showing it', async () => {
+        changeFollower.enable();
+        disposables.push(vscode.window.onDidChangeVisibleTextEditors(editors => {
+            if (editors.some(editor => editor.document.uri.toString() === uri.toString())) {
+                changeFollower.disable(true);
+            }
+        }));
+
+        await showChange();
+
+        assert.strictEqual(changeFollower.isEnabled, false);
+        assert.strictEqual(changeFollower['activeHighlights'].size, 0);
+    });
+
+    test('Should still show and highlight changes while enabled', async () => {
+        changeFollower.enable();
+
+        await showChange();
+
+        assert.ok(vscode.window.visibleTextEditors.some(editor => editor.document.uri.toString() === uri.toString()));
+        assert.ok(changeFollower['activeHighlights'].has(uri.toString()));
+    });
+});

--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { setTimeout as delay } from 'timers/promises';
 import { debounce } from '../../debounce';
 
 suite('Debounce Test Suite', () => {
@@ -55,4 +56,42 @@ suite('Debounce Test Suite', () => {
             done();
         }, 400);
     });
+
+    for (const rejectAsync of [false, true]) {
+        test(`Should contain ${rejectAsync ? 'asynchronous' : 'synchronous'} errors and allow later calls`, async () => {
+            const expectedError = new Error('Debounced callback failed');
+            const unhandledErrors: unknown[] = [];
+            const recordUnhandledError = (error: unknown) => {
+                unhandledErrors.push(error);
+            };
+            let callCount = 0;
+            const debouncer = debounce(() => {
+                callCount++;
+                if (callCount === 1) {
+                    if (rejectAsync) {
+                        return Promise.reject(expectedError);
+                    }
+                    throw expectedError;
+                }
+            }, 0);
+
+            process.on('uncaughtException', recordUnhandledError);
+            process.on('unhandledRejection', recordUnhandledError);
+
+            try {
+                debouncer.call();
+                await delay(20);
+                assert.strictEqual(callCount, 1);
+
+                debouncer.call();
+                await delay(20);
+                assert.strictEqual(callCount, 2);
+                assert.deepStrictEqual(unhandledErrors, []);
+            } finally {
+                debouncer.cancel();
+                process.removeListener('uncaughtException', recordUnhandledError);
+                process.removeListener('unhandledRejection', recordUnhandledError);
+            }
+        });
+    }
 });


### PR DESCRIPTION
## Summary

Harden debounced change processing and avoid navigating or highlighting after follow mode is disabled while a document or editor is being opened.

## Changes

### `src/debounce.ts`
- Await the debounced callback and catch both synchronous exceptions and rejected promises.
- Log callback failures without preventing subsequent debounced calls.

### `src/changeFollower.ts`
- Check that follow mode is still enabled before opening the document and after each awaited document/editor operation.
- Verify that the returned editor is still visible before scrolling or highlighting.
- Keep scrolling and highlighting immediately after the final guard, without an extra timer delay. `setTimeout(0)` is not an editor-readiness guarantee and would introduce another opportunity for disabling or closing the editor after the guard.

### CI compatibility
- Upgrade `@vscode/test-electron` to 3.1.0 and regenerate the lockfile. This fixes macOS launches after VS Code removed its legacy `Contents/MacOS/Electron` executable symlink.
- Use Node.js 22 in CI, release, and dev-release jobs to meet the upgraded runner's minimum version, and document the development requirement.

## Regression coverage

- Synchronous and asynchronous callback errors are contained, and later debounce calls still execute.
- Disabled followers do not open documents.
- Disabling while opening a document prevents showing it.
- Disabling while showing an editor prevents highlighting it.
- Enabled followers still show and highlight changes normally.

## Reported symptom and scope

The original report describes following stopping after the first file change, particularly on Apple Silicon Macs. These changes are defensive hardening, not yet a demonstrated root-cause fix for that symptom. `showChange()` already catches errors from normal document/editor operations, so an actual exception trace or minimal reproduction is still needed to connect the reported failure to this change.