### PR TITLE
Add opt-in cleanup of follow-mode tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the "File Change Follower" extension will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Opt-in `fileChangeFollower.autoCloseOnSwitch` setting to close other tabs opened
+  by live follow mode while preserving existing, manually opened, dirty, pinned,
+  and user-moved tabs.
+
 ## [0.1.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Configure the extension in VS Code settings:
 | `fileChangeFollower.includePatterns` | `["**/*"]` | Glob patterns for files to include |
 | `fileChangeFollower.excludePatterns` | `["**/node_modules/**", "**/.git/**", ...]` | Glob patterns for files to exclude |
 | `fileChangeFollower.respectGitignore` | `true` | Ignore files listed in .gitignore |
+| `fileChangeFollower.autoCloseOnSwitch` | `false` | Close other eligible tabs opened by live follow mode when showing the next changed file |
 | `fileChangeFollower.debounceMs` | `150` | Debounce interval (0-2000ms) |
 | `fileChangeFollower.highlightDuration` | `2000` | How long to highlight changes (0 to disable) |
 | `fileChangeFollower.recordingsPath` | `".recordings"` | Directory for saved recordings |
@@ -102,12 +103,31 @@ Configure the extension in VS Code settings:
     "**/out/**"
   ],
   "fileChangeFollower.debounceMs": 150,
+  "fileChangeFollower.autoCloseOnSwitch": false,
   "fileChangeFollower.highlightDuration": 2000,
   "fileChangeFollower.recordingsPath": ".recordings",
   "fileChangeFollower.liveDelaySeconds": 5,
   "fileChangeFollower.defaultPlaybackSpeed": 1
 }
 ```
+
+### Automatically Close Follow Tabs
+
+Set `fileChangeFollower.autoCloseOnSwitch` to `true` to keep only the current
+eligible follow tab open. Other tabs opened by live follow mode close only after
+the next changed file is successfully shown. The last followed file stays open
+when changes stop or follow mode is disabled.
+
+Tabs that were already open (including background tabs and other editor groups),
+tabs opened manually during following, and user-created splits are preserved.
+Editing, explicitly pinning, or moving a follow tab to another group takes it out
+of automatic cleanup, even if it is later saved or unpinned. Closing a tab and
+reopening it manually also protects it.
+
+Turning this setting or follow mode off clears tab ownership without closing
+anything. Turning it back on only manages newly opened follow tabs. This setting
+does not pause navigation while reviewing a file and does not affect recording
+playback.
 
 ## Recording & Playback
 

--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
           "default": true,
           "description": "Automatically disable follow mode when a manual edit is made in the editor"
         },
+        "fileChangeFollower.autoCloseOnSwitch": {
+          "type": "boolean",
+          "default": false,
+          "description": "Close other tabs opened by live follow mode after showing the next changed file. Existing tabs, tabs opened manually, and dirty or explicitly pinned tabs are preserved. Does not affect recording playback."
+        },
         "fileChangeFollower.debounceMs": {
           "type": "number",
           "default": 150,

--- a/src/changeFollower.ts
+++ b/src/changeFollower.ts
@@ -22,6 +22,10 @@ export class ChangeFollower implements vscode.Disposable {
     private activeHighlights: Map<string, NodeJS.Timeout> = new Map();
     private gitignoreCache: Map<string, Ignore> = new Map();
     private recentExternalChanges: Map<string, NodeJS.Timeout> = new Map();
+    private readonly autoOpenedTabs = new Map<vscode.Tab, vscode.TabGroup>();
+    private navigationQueue: Promise<void> = Promise.resolve();
+    private followSession = 0;
+    private tabTrackingGeneration = 0;
     private static readonly EXTERNAL_CHANGE_WINDOW_MS = 2000;
     private readonly _onDidAutoDisable = new vscode.EventEmitter<void>();
     readonly onDidAutoDisable = this._onDidAutoDisable.event;
@@ -50,6 +54,7 @@ export class ChangeFollower implements vscode.Disposable {
         }
 
         this._isEnabled = true;
+        this.followSession++;
         this.setupListeners();
         vscode.window.showInformationMessage('File Change Follower: Follow mode enabled');
     }
@@ -60,8 +65,11 @@ export class ChangeFollower implements vscode.Disposable {
         }
 
         this._isEnabled = false;
+        this.followSession++;
+        this.processChangesDebouncer?.cancel();
         this.clearListeners();
         this.pendingChanges.clear();
+        this.clearAutoOpenedTabs();
         this.clearAllHighlights();
         this.clearAllExternalChangeTracking();
         if (!silent) {
@@ -73,13 +81,20 @@ export class ChangeFollower implements vscode.Disposable {
         this.setupDebouncer();
         this.setupHighlightDecoration();
         this.gitignoreCache.clear();
+        if (!this.configManager.autoCloseOnSwitch) {
+            this.clearAutoOpenedTabs();
+        }
     }
 
     private setupDebouncer(): void {
+        this.processChangesDebouncer?.cancel();
         this.processChangesDebouncer = debounce(
             () => this.processChanges(),
             this.configManager.debounceMs
         );
+        if (this._isEnabled && this.pendingChanges.size > 0) {
+            this.processChangesDebouncer.call();
+        }
     }
 
     private setupHighlightDecoration(): void {
@@ -116,7 +131,18 @@ export class ChangeFollower implements vscode.Disposable {
             this.handleFileChanged(uri);
         });
 
-        this.disposables.push(textChangeListener, fileWatcher, createListener, changeListener);
+        const tabChangeListener = vscode.window.tabGroups.onDidChangeTabs((event) => {
+            for (const tab of event.closed) {
+                this.autoOpenedTabs.delete(tab);
+            }
+            for (const tab of event.changed) {
+                if (tab.isDirty || tab.isPinned || this.autoOpenedTabs.get(tab) !== tab.group) {
+                    this.autoOpenedTabs.delete(tab);
+                }
+            }
+        });
+
+        this.disposables.push(textChangeListener, fileWatcher, createListener, changeListener, tabChangeListener);
     }
 
     private clearListeners(): void {
@@ -335,19 +361,44 @@ export class ChangeFollower implements vscode.Disposable {
             return;
         }
 
-        await this.showChange(mostRecent);
+        const changeToShow = mostRecent;
+        const session = this.followSession;
+        // Opening and closing tabs must finish in order, even across debounce intervals.
+        this.navigationQueue = this.navigationQueue.then(async () => {
+            if (this.isCurrentSession(session)) {
+                await this.showChange(changeToShow, session);
+            }
+        });
+        await this.navigationQueue;
     }
 
-    private async showChange(change: PendingChange): Promise<void> {
+    private isCurrentSession(session: number): boolean {
+        return this._isEnabled && this.followSession === session;
+    }
+
+    private async showChange(change: PendingChange, session: number): Promise<void> {
         try {
             // Open the document
             const document = await vscode.workspace.openTextDocument(change.uri);
-            
+            if (!this.isCurrentSession(session)) {
+                return;
+            }
+
+            // Snapshot tabs, not documents: include background tabs and all editor groups,
+            // including tabs the user opened while the document was loading.
+            const existingTabs = this.configManager.autoCloseOnSwitch
+                ? new Set(this.getOpenTabs())
+                : undefined;
+            const trackingGeneration = this.tabTrackingGeneration;
+
             // Show the document without stealing focus from the terminal
             const editor = await vscode.window.showTextDocument(document, {
                 preview: false,
                 preserveFocus: true
             });
+            if (!this.isCurrentSession(session)) {
+                return;
+            }
 
             // Find the best range to reveal (prefer last change)
             const rangeToReveal = change.ranges.length > 0 
@@ -361,9 +412,63 @@ export class ChangeFollower implements vscode.Disposable {
             if (this.configManager.highlightDuration > 0 && this.highlightDecorationType) {
                 this.applyHighlight(editor, change.ranges);
             }
+
+            if (existingTabs && this.configManager.autoCloseOnSwitch && trackingGeneration === this.tabTrackingGeneration) {
+                const currentTab = vscode.window.tabGroups.all
+                    .find(group => group.viewColumn === editor.viewColumn)?.tabs
+                    .find(tab => tab.input instanceof vscode.TabInputText
+                        && tab.input.uri.toString() === document.uri.toString());
+                if (currentTab) {
+                    if (!existingTabs.has(currentTab) && !currentTab.isDirty && !currentTab.isPinned) {
+                        this.autoOpenedTabs.set(currentTab, currentTab.group);
+                    }
+                    await this.closeOtherAutoOpenedTabs(currentTab, session, trackingGeneration);
+                }
+            }
         } catch (error) {
             // File might have been deleted or is binary
             console.log(`File Change Follower: Could not open ${change.uri.fsPath}:`, error);
+        }
+    }
+
+    private getOpenTabs(): vscode.Tab[] {
+        return vscode.window.tabGroups.all.flatMap(group => [...group.tabs]);
+    }
+
+    private clearAutoOpenedTabs(): void {
+        this.autoOpenedTabs.clear();
+        this.tabTrackingGeneration++;
+    }
+
+    private async closeOtherAutoOpenedTabs(currentTab: vscode.Tab, session: number, trackingGeneration: number): Promise<void> {
+        for (const [tab, group] of this.autoOpenedTabs) {
+            if (!this.isCurrentSession(session) || !this.configManager.autoCloseOnSwitch
+                || trackingGeneration !== this.tabTrackingGeneration) {
+                return;
+            }
+            if (tab === currentTab) {
+                continue;
+            }
+
+            const openTabs = this.getOpenTabs();
+            if (!openTabs.includes(currentTab)) {
+                return;
+            }
+            if (!openTabs.includes(tab) || tab.isDirty || tab.isPinned || tab.group !== group) {
+                this.autoOpenedTabs.delete(tab);
+                continue;
+            }
+
+            const label = tab.label;
+            try {
+                if (await vscode.window.tabGroups.close(tab, true)) {
+                    this.autoOpenedTabs.delete(tab);
+                } else {
+                    console.log(`File Change Follower: Could not close tab ${label}: close was cancelled`);
+                }
+            } catch (error) {
+                console.log(`File Change Follower: Could not close tab ${label}:`, error);
+            }
         }
     }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,6 +33,10 @@ export class ConfigurationManager {
         return this.config.get<boolean>('disableOnManualEdit', true);
     }
 
+    get autoCloseOnSwitch(): boolean {
+        return this.config.get<boolean>('autoCloseOnSwitch', false);
+    }
+
     get debounceMs(): number {
         return this.config.get<number>('debounceMs', 150);
     }

--- a/src/test/suite/autoCloseOnSwitch.test.ts
+++ b/src/test/suite/autoCloseOnSwitch.test.ts
@@ -1,0 +1,408 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChangeFollower } from '../../changeFollower';
+import { ConfigurationManager } from '../../configuration';
+
+class TestConfigurationManager extends ConfigurationManager {
+    autoClose = true;
+
+    override get autoCloseOnSwitch(): boolean {
+        return this.autoClose;
+    }
+
+    override get disableOnManualEdit(): boolean {
+        return false;
+    }
+
+    override get highlightDuration(): number {
+        return 0;
+    }
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>(complete => { resolve = complete; });
+    return { promise, resolve };
+}
+
+suite('Follow Tab Auto-Close Test Suite', function () {
+    this.timeout(15000);
+
+    let config: TestConfigurationManager;
+    let follower: ChangeFollower;
+    let tempDir: string;
+    let subscriptions: vscode.Disposable[];
+
+    function allTabs(): vscode.Tab[] {
+        return vscode.window.tabGroups.all.flatMap(group => [...group.tabs]);
+    }
+
+    function tabsFor(uri: vscode.Uri): vscode.Tab[] {
+        return allTabs().filter(tab => tab.input instanceof vscode.TabInputText
+            && tab.input.uri.toString() === uri.toString());
+    }
+
+    function createFile(name: string): vscode.Uri {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, 'initial content\n');
+        return vscode.Uri.file(filePath);
+    }
+
+    async function openFile(uri: vscode.Uri, options: vscode.TextDocumentShowOptions = {}): Promise<vscode.TextEditor> {
+        const document = await vscode.workspace.openTextDocument(uri);
+        return vscode.window.showTextDocument(document, { preview: false, ...options });
+    }
+
+    async function followFile(uri: vscode.Uri): Promise<void> {
+        // Exercise the real navigation pipeline without waiting for filesystem/debounce timing.
+        follower['queueChange'](uri, [new vscode.Range(0, 0, 0, 0)]);
+        follower['processChangesDebouncer']?.cancel();
+        await follower['processChanges']();
+    }
+
+    function setAutoClose(enabled: boolean): void {
+        config.autoClose = enabled;
+        follower.onConfigurationChanged();
+    }
+
+    setup(() => {
+        config = new TestConfigurationManager();
+        follower = new ChangeFollower(config);
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcf-auto-close-'));
+        subscriptions = [];
+    });
+
+    teardown(async () => {
+        for (const subscription of subscriptions) {
+            subscription.dispose();
+        }
+        follower.dispose();
+        await follower['navigationQueue'];
+        for (const document of vscode.workspace.textDocuments) {
+            if (document.uri.fsPath.startsWith(tempDir + path.sep) && document.isDirty) {
+                assert.ok(await document.save());
+            }
+        }
+        const testTabs = allTabs().filter(tab => tab.input instanceof vscode.TabInputText
+            && tab.input.uri.fsPath.startsWith(tempDir + path.sep));
+        assert.ok(await vscode.window.tabGroups.close(testTabs, true));
+        await fs.promises.rm(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    });
+
+    test('Setting is opt-in in both the manifest and configuration manager', () => {
+        const setting = vscode.workspace.getConfiguration('fileChangeFollower').inspect<boolean>('autoCloseOnSwitch');
+        assert.strictEqual(setting?.defaultValue, false);
+        assert.strictEqual(new ConfigurationManager().autoCloseOnSwitch, false);
+    });
+
+    test('Disabled setting preserves the existing tab accumulation behavior', async () => {
+        setAutoClose(false);
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        await followFile(first);
+        await followFile(second);
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(second).length, 1);
+    });
+
+    test('Closes the previous follow tab but keeps the current and final tab', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        await followFile(first);
+        const firstTab = tabsFor(first)[0];
+        assert.ok(firstTab);
+        await followFile(first);
+        assert.ok(allTabs().includes(firstTab), 'Repeated changes must reuse the current tab');
+        await followFile(second);
+        assert.strictEqual(tabsFor(first).length, 0);
+        assert.strictEqual(tabsFor(second).length, 1);
+        follower.disable();
+        assert.strictEqual(tabsFor(second).length, 1, 'Stopping follow mode must leave the last tab open');
+    });
+
+    test('Protects pre-existing background and preview tabs across groups', async () => {
+        await openFile(createFile('background.txt'), { viewColumn: vscode.ViewColumn.One });
+        await openFile(createFile('foreground.txt'), { viewColumn: vscode.ViewColumn.One });
+        const preview = createFile('preview.txt');
+        await openFile(preview, { viewColumn: vscode.ViewColumn.Two, preview: true });
+        const originalTabs = allTabs();
+        assert.ok(tabsFor(preview)[0].isPreview);
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        await followFile(createFile('second.txt'));
+        assert.strictEqual(tabsFor(first).length, 0);
+        for (const tab of originalTabs) {
+            assert.ok(allTabs().includes(tab), `Pre-existing tab ${tab.label} must remain open`);
+        }
+    });
+
+    test('Can follow a previously auto-closed file again without accumulating tabs', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        await followFile(first);
+        await followFile(second);
+        await followFile(first);
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(second).length, 0);
+        await followFile(second);
+        assert.strictEqual(tabsFor(first).length, 0);
+        assert.strictEqual(tabsFor(second).length, 1);
+    });
+
+    test('Protects tabs opened manually after follow mode starts, even when followed later', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const manual = createFile('manual.txt');
+        await followFile(first);
+        await openFile(manual);
+        const manualTab = tabsFor(manual)[0];
+        await followFile(manual);
+        assert.strictEqual(tabsFor(first).length, 0, 'Switching to an existing tab should still clean up follow tabs');
+        await followFile(createFile('second.txt'));
+        assert.ok(allTabs().includes(manualTab));
+    });
+
+    test('Protects a user-created split of a followed file', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        const originalTab = tabsFor(first)[0];
+        await openFile(first, { viewColumn: vscode.ViewColumn.Beside });
+        const splitTab = tabsFor(first).find(tab => tab !== originalTab);
+        assert.ok(splitTab);
+        await followFile(createFile('second.txt'));
+        assert.ok(!allTabs().includes(originalTab));
+        assert.ok(allTabs().includes(splitTab));
+        assert.strictEqual(tabsFor(first).length, 1);
+    });
+
+    test('Protects a follow tab moved by the user to another group', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        const originalGroup = tabsFor(first)[0].group;
+        await openFile(first);
+        await vscode.commands.executeCommand('moveActiveEditor', { to: 'right', by: 'group' });
+        assert.notStrictEqual(tabsFor(first)[0].group, originalGroup);
+        await followFile(createFile('second.txt'));
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+    });
+
+    test('Protects dirty follow tabs, including after they are saved', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        const editor = await openFile(first);
+        await editor.edit(edit => edit.insert(new vscode.Position(0, 0), 'manual edit '));
+        assert.ok(editor.document.isDirty);
+        await followFile(createFile('second.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.ok(await editor.document.save());
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+    });
+
+    test('Protects explicitly pinned follow tabs, including after they are unpinned', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        await openFile(first);
+        await vscode.commands.executeCommand('workbench.action.pinEditor');
+        assert.ok(tabsFor(first)[0].isPinned);
+        await followFile(createFile('second.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        await openFile(first);
+        await vscode.commands.executeCommand('workbench.action.unpinEditor');
+        assert.ok(!tabsFor(first)[0].isPinned);
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+    });
+
+    test('Does not reclaim ownership when the user closes and reopens a follow tab', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        assert.ok(await vscode.window.tabGroups.close(tabsFor(first), true));
+        await openFile(first);
+        await followFile(first);
+        await followFile(createFile('second.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+    });
+
+    test('Re-enabling follow mode protects tabs left by the previous session', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        await followFile(first);
+        follower.disable();
+        follower.enable();
+        await followFile(second);
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(second).length, 0);
+    });
+
+    test('Toggling the setting clears ownership without closing existing tabs', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        const third = createFile('third.txt');
+        await followFile(first);
+        setAutoClose(false);
+        await followFile(second);
+        setAutoClose(true);
+        await followFile(third);
+        await followFile(createFile('fourth.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(second).length, 1);
+        assert.strictEqual(tabsFor(third).length, 0);
+    });
+
+    test('Failed navigation preserves the last follow tab and allows later navigation', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        await followFile(first);
+        await followFile(vscode.Uri.file(path.join(tempDir, 'missing.txt')));
+        assert.strictEqual(tabsFor(first).length, 1);
+        await followFile(createFile('second.txt'));
+        assert.strictEqual(tabsFor(first).length, 0);
+    });
+
+    test('Refreshing configuration retains pending debounced changes', async () => {
+        follower.enable();
+        const pending = createFile('pending.txt');
+        const opened = deferred();
+        subscriptions.push(vscode.window.tabGroups.onDidChangeTabs(event => {
+            if (event.opened.some(tab => tab.input instanceof vscode.TabInputText
+                && tab.input.uri.toString() === pending.toString())) {
+                opened.resolve();
+            }
+        }));
+        follower['queueChange'](pending, [new vscode.Range(0, 0, 0, 0)]);
+        follower.onConfigurationChanged();
+        await opened.promise;
+        await follower['navigationQueue'];
+        assert.strictEqual(tabsFor(pending).length, 1);
+    });
+
+    test('Serializes overlapping navigation and cleanup', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        const third = createFile('third.txt');
+        const started = deferred();
+        const resume = deferred();
+        const showChange = follower['showChange'].bind(follower);
+        const navigationOrder: string[] = [];
+        follower['showChange'] = async (change, session) => {
+            navigationOrder.push(change.uri.toString());
+            if (change.uri.toString() === first.toString()) {
+                started.resolve();
+                await resume.promise;
+            }
+            await showChange(change, session);
+        };
+
+        const firstNavigation = followFile(first);
+        try {
+            await started.promise;
+            const secondNavigation = followFile(second);
+            const thirdNavigation = followFile(third);
+            await Promise.resolve();
+            assert.deepStrictEqual(navigationOrder, [first.toString()]);
+            resume.resolve();
+            await Promise.all([firstNavigation, secondNavigation, thirdNavigation]);
+            assert.deepStrictEqual(navigationOrder, [first, second, third].map(uri => uri.toString()));
+            assert.strictEqual(tabsFor(first).length, 0);
+            assert.strictEqual(tabsFor(second).length, 0);
+            assert.strictEqual(tabsFor(third).length, 1);
+        } finally {
+            resume.resolve();
+        }
+    });
+
+    test('Disabling and re-enabling invalidates already queued navigation', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const second = createFile('second.txt');
+        const third = createFile('third.txt');
+        const firstNavigation = followFile(first);
+        const secondNavigation = followFile(second);
+        follower.disable();
+        follower.enable();
+        await Promise.all([firstNavigation, secondNavigation, followFile(third)]);
+        assert.strictEqual(tabsFor(first).length, 0);
+        assert.strictEqual(tabsFor(second).length, 0);
+        assert.strictEqual(tabsFor(third).length, 1);
+    });
+
+    test('Does not show a loaded document after its follow session has ended', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const loading = createFile('loading.txt');
+        await followFile(first);
+        let interrupted = false;
+        subscriptions.push(vscode.workspace.onDidOpenTextDocument(document => {
+            if (document.uri.toString() === loading.toString()) {
+                interrupted = true;
+                follower.disable();
+                follower.enable();
+            }
+        }));
+        await followFile(loading);
+        assert.ok(interrupted);
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(loading).length, 0);
+    });
+
+    test('Does not adopt or clean up tabs when the session changes during display', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const opening = createFile('opening.txt');
+        await followFile(first);
+        let interrupted = false;
+        subscriptions.push(vscode.window.tabGroups.onDidChangeTabs(event => {
+            if (event.opened.some(tab => tab.input instanceof vscode.TabInputText
+                && tab.input.uri.toString() === opening.toString())) {
+                interrupted = true;
+                follower.disable();
+                follower.enable();
+            }
+        }));
+        await followFile(opening);
+        assert.ok(interrupted);
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(opening).length, 1);
+    });
+
+    test('Does not adopt tabs across a setting toggle during display', async () => {
+        follower.enable();
+        const first = createFile('first.txt');
+        const opening = createFile('opening.txt');
+        await followFile(first);
+        let interrupted = false;
+        subscriptions.push(vscode.window.tabGroups.onDidChangeTabs(event => {
+            if (event.opened.some(tab => tab.input instanceof vscode.TabInputText
+                && tab.input.uri.toString() === opening.toString())) {
+                interrupted = true;
+                setAutoClose(false);
+                setAutoClose(true);
+            }
+        }));
+        await followFile(opening);
+        assert.ok(interrupted);
+        await followFile(createFile('third.txt'));
+        assert.strictEqual(tabsFor(first).length, 1);
+        assert.strictEqual(tabsFor(opening).length, 1);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `fileChangeFollower.autoCloseOnSwitch` (default: `false`) to close other eligible tabs opened by live follow mode after successfully showing the next changed file.

- Tracks ownership per tab across editor groups, preserving pre-existing tabs, manually opened tabs, and user-created splits.
- Relinquishes ownership when a tab is edited, explicitly pinned, moved to another group, or closed. Saving, unpinning, or manually reopening a tab does not make it eligible for cleanup again.
- Serializes navigation and guards asynchronous operations across disabling/re-enabling follow mode and configuration changes.
- Keeps the last followed tab open and leaves recording playback unchanged. Idle-close timers and pause-on-review behavior are intentionally out of scope.
- Documents the setting and adds 20 regression tests covering ownership, lifecycle, concurrency, failed navigation, and configuration changes.

Includes the latest `main` changes from #21, retaining its debounce error handling and editor-visibility guards.

## Validation

- TypeScript compilation passed.
- ESLint passed for the affected TypeScript files.
- All 75 extension tests passed on Windows with VS Code 1.136.1.

Fixes #17.

Related to #22; this implements safe close-on-switch behavior, not its additional idle-timeout request.